### PR TITLE
fix: handle refunds and duplicate payees in split transactions

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,22 +69,41 @@ class Main():
         return detailed_transactions, tags
     
     async def build_user_share_entries(self, transaction, group_member_info):
+        '''Build the final list of per-user paid/owed shares for a transaction.
+
+        Walks the transaction (or each of its split children), delegates owed-share
+        computation to compute_shares, merges duplicate users, and assigns the full
+        paid-share to the root user — the single payer Splitwise requires.  Guarantees
+        exactly one entry per user and sum(paid-share) == transaction cost.'''
         user_shares = [] # list of complete expense entries a set of user_shares
         # Check if this object was split.  If so, then grab total price from original transaction
         if transaction['getTransaction']['hasSplitTransactions']:
             for transaction_child in transaction['getTransaction']['splitTransactions']:
-                transaction_child =  await self.mm.get_transaction_details(transaction_child['id'])
+                transaction_child = await self.mm.get_transaction_details(transaction_child['id'])
                 user_shares.append(await self.compute_shares(transaction_child, group_member_info)) # compute on a per split basis
         else:
             user_shares.append(await self.compute_shares(transaction, group_member_info)) # compute as a whole
         user_shares = self.flatten_list(user_shares)
+        user_shares = self.merge_user_shares(user_shares)
 
-        # Check if root user is mentioned as oweing a portion.  
-        # If root owes no part of the transaction, add root user for computational reasons. SW requires a payee
+        # Splitwise requires a payer. Root user holds the transaction on their account,
+        # so they are always the payer of the full amount. Update existing entry or inject.
         root_user_name = self.config['monarch_user_firstname']
-        if not any(p.get('name') == root_user_name for p in user_shares): # checks if root user is in user_shares list
-            user_shares.append(await self.compute_shares(transaction, group_member_info, name_list_override=[root_user_name], owed_share_array_override=[0])) # appends if not
-            user_shares = self.flatten_list(user_shares)
+        total_amount = abs(transaction['getTransaction']['amount'])
+        root_entry = next((e for e in user_shares if e['name'] == root_user_name), None)
+        if root_entry:
+            root_entry['paid-share'] = total_amount
+        else:
+            root_user_id = next(
+                (m['memberId'] for m in group_member_info if m['first_name'] == root_user_name),
+                None,
+            )
+            user_shares.append({
+                "name": root_user_name,
+                "userId": root_user_id,
+                "paid-share": total_amount,
+                "owed-share": 0,
+            })
 
         return user_shares
 
@@ -97,46 +116,87 @@ class Main():
                 flat.append(item)
         return flat
 
-    async def compute_shares(self, transaction, group_member_info, name_list_override = None, owed_share_array_override = None):
-        '''Takes a detailed monarch transaction and calculates what each user owes based on tags and splits'''    
+    def to_refund_shares(self, user_shares):
+        '''Transform normal-expense shares into refund-expense shares.
+
+        Semantics: a refund lands on root user's account. Only the non-root portion
+        of the refund belongs on the group ledger — root's own share simply returns
+        to them personally. In the resulting Splitwise expense the non-root payees
+        become "payers" (their debt decreases by their share of the refund) and
+        root becomes the sole "ower" of that reduced cost.
+
+        Example: $20 refund, original 70/30 split (root paid) →
+            Root:   paid=0,  owed=6     (non-root total)
+            Friend: paid=6,  owed=0
+            cost = 6
+
+        Done in integer cents (same convention as calculate_shares) to guarantee
+        no float drift.  Only converts back to dollars at the output boundary.
+
+        Returns (new_shares, new_cost).'''
+        root_user_name = self.config['monarch_user_firstname']
+        new_shares = []
+        new_cost_cents = 0
+        for entry in user_shares:
+            paid_cents = int(round(entry['paid-share'] * 100))
+            owed_cents = int(round(entry['owed-share'] * 100))
+            if entry['name'] == root_user_name:
+                new_owed_cents = paid_cents - owed_cents
+                new_shares.append({**entry, 'paid-share': 0, 'owed-share': round(new_owed_cents / 100, 2)})
+                new_cost_cents += new_owed_cents
+            else:
+                new_shares.append({**entry, 'paid-share': round(owed_cents / 100, 2), 'owed-share': 0})
+        return new_shares, round(new_cost_cents / 100, 2)
+
+    def merge_user_shares(self, user_shares):
+        '''Consolidate entries by userId, summing paid-share and owed-share.
+
+        Splitwise rejects an expense if the same user appears twice, so any path that
+        can produce duplicates (e.g. a payee tagged in multiple split children) must
+        funnel through here before the shares are submitted.'''
+        merged = {}
+        for entry in user_shares:
+            uid = entry['userId']
+            if uid in merged:
+                merged[uid]['paid-share'] = round(merged[uid]['paid-share'] + entry['paid-share'], 2)
+                merged[uid]['owed-share'] = round(merged[uid]['owed-share'] + entry['owed-share'], 2)
+            else:
+                merged[uid] = dict(entry)
+        return list(merged.values())
+
+    async def compute_shares(self, transaction, group_member_info):
+        '''Compute the owed-share distribution for a single transaction (or split child).
+
+        Reads payee-colored tags to decide who owes, then uses calculate_shares to
+        divide the amount evenly (cent-precise).  If no payee tags are present, falls
+        back to an even split across every member of group_member_info.  paid-share
+        is deliberately left at 0 — assigning it is the caller's responsibility so
+        that callers aggregating over multiple children don't end up double-counting.'''
+        # List of all names associated with a particular transaction
+        names = [
+            tag['name']
+            for tag in transaction['getTransaction']['tags']
+            if tag['color'] == self.config['key_tag_colors']['payee']
+        ]
+        if not names and group_member_info:
+            names = [m['first_name'] for m in group_member_info]
+
+        amount = abs(transaction['getTransaction']['amount'])
+        # creates an array of who owe's what.  When not easily divisible, the extra cent(s) are randomly assigned to an individual
+        owed_share_array = self.calculate_shares(amount, len(names))
+
         user_entry = [] # list of complete expense entries for a user
-        
-        # Overrides for when adding the root user when not mentioned in tagging.  Otherwise, compute shares as normal
-        if not name_list_override:
-            counter = 0
-            names = [] # List of all names associated with a particular transaction
-            for tag in transaction['getTransaction']['tags']:
-                if tag['color'] == self.config['key_tag_colors']['payee']:
-                    names.append(tag['name'])
-                    counter += 1
-        else:
-            counter = len(name_list_override)
-            names = name_list_override
-        if not owed_share_array_override:
-            # creates an array of who owe's what.  When not easily divisible, the extra cent(s) are randomly assigned to an individual
-            owed_share_array =  self.calculate_shares(transaction['getTransaction']['amount'] * -1, counter)
-        else:
-            owed_share_array = owed_share_array_override
-    
-        # Compiles user information and selects payee vs payer
         for name, owed_share in zip(names, owed_share_array):
-            paid_share = 0.00
-            userId = None
-            for member in group_member_info:
-                if member['first_name'] == name:
-                    userId = member['memberId']
-                    break
-            if name == self.config['monarch_user_firstname']:
-                if transaction['getTransaction']['isSplitTransaction']:
-                    paid_share = transaction['getTransaction']['originalTransaction']['amount'] * -1
-                else:
-                    paid_share = transaction['getTransaction']['amount'] * -1 
-            user_entry.append({"name": name,
-                            "userId": userId,
-                            "paid-share": paid_share,
-                            "owed-share": owed_share
-                            })
-        
+            userId = next(
+                (m['memberId'] for m in group_member_info if m['first_name'] == name),
+                None,
+            )
+            user_entry.append({
+                "name": name,
+                "userId": userId,
+                "paid-share": 0.00,
+                "owed-share": owed_share,
+            })
         return user_entry
 
     
@@ -255,15 +315,30 @@ class Main():
 
             '''
             Cost
+            Positive Monarch amount = refund/income; flip to a reverse-roles Splitwise
+            expense so the correct party's debt decreases.  Zero-amount transactions
+            are almost always a stray tag and get skipped.
             '''
-            expense_details['cost'] = transaction['getTransaction']['amount'] * -1
-            
+            raw_amount = transaction['getTransaction']['amount']
+            is_refund = raw_amount > 0
+            expense_details['cost'] = abs(raw_amount)
+            if expense_details['cost'] == 0:
+                print(f"SKIPPING $0 transaction (tag likely in error): "
+                      f"{transaction['getTransaction']['plaidName']} | {transaction['getTransaction']['date']}")
+                continue
+
             '''
             Calculate each user amount
             '''
             # If SW group member info was found
             if group_member_info:
-                expense_details['users'] = await self.build_user_share_entries(transaction, group_member_info)       
+                expense_details['users'] = await self.build_user_share_entries(transaction, group_member_info)
+                if is_refund:
+                    expense_details['users'], expense_details['cost'] = self.to_refund_shares(expense_details['users'])
+                    if expense_details['cost'] == 0:
+                        print(f"SKIPPING refund where only root user was tagged (no group balance change): "
+                              f"{transaction['getTransaction']['plaidName']} | {transaction['getTransaction']['date']}")
+                        continue
                     
             '''
             Description/SW Title
@@ -285,7 +360,8 @@ class Main():
             This part double checks SW entry and alters monarch tags to show the transaction has been processed
             '''
             if expense_Id:
-                print(f"""Successfully created an expense with the following details: 
+                expense_type = "refund" if is_refund else "expense"
+                print(f"""Successfully created a {expense_type} with the following details:
                     Expense Description: {expense_details['description']}
                     Expense Cost: {expense_details['cost']}
                     Group: {expense_details['groupId']['name']}""")

--- a/tests/fixtures/data/split_same_payee_child_1.json
+++ b/tests/fixtures/data/split_same_payee_child_1.json
@@ -1,0 +1,43 @@
+{
+    "getTransaction": {
+        "id": "100000000000000051",
+        "amount": -0.44,
+        "pending": false,
+        "isRecurring": false,
+        "date": "2026-01-23",
+        "originalDate": "2026-01-23",
+        "hideFromReports": false,
+        "needsReview": false,
+        "reviewedAt": null,
+        "reviewedByUser": null,
+        "plaidName": "DUPLICATE PAYEE MERCHANT",
+        "notes": null,
+        "hasSplitTransactions": false,
+        "isSplitTransaction": true,
+        "isManual": false,
+        "splitTransactions": [],
+        "originalTransaction": {
+            "id": "100000000000000050",
+            "amount": -0.68,
+            "__typename": "Transaction"
+        },
+        "attachments": [],
+        "tags": [
+            {
+                "id": "200000000000000001",
+                "name": "Roomies",
+                "color": "#AB89CD",
+                "order": 0,
+                "__typename": "TransactionTag"
+            },
+            {
+                "id": "200000000000000002",
+                "name": "Alex",
+                "color": "#EF12AB",
+                "order": 1,
+                "__typename": "TransactionTag"
+            }
+        ],
+        "__typename": "Transaction"
+    }
+}

--- a/tests/fixtures/data/split_same_payee_child_2.json
+++ b/tests/fixtures/data/split_same_payee_child_2.json
@@ -1,0 +1,43 @@
+{
+    "getTransaction": {
+        "id": "100000000000000052",
+        "amount": -0.24,
+        "pending": false,
+        "isRecurring": false,
+        "date": "2026-01-23",
+        "originalDate": "2026-01-23",
+        "hideFromReports": false,
+        "needsReview": false,
+        "reviewedAt": null,
+        "reviewedByUser": null,
+        "plaidName": "DUPLICATE PAYEE MERCHANT",
+        "notes": null,
+        "hasSplitTransactions": false,
+        "isSplitTransaction": true,
+        "isManual": false,
+        "splitTransactions": [],
+        "originalTransaction": {
+            "id": "100000000000000050",
+            "amount": -0.68,
+            "__typename": "Transaction"
+        },
+        "attachments": [],
+        "tags": [
+            {
+                "id": "200000000000000001",
+                "name": "Roomies",
+                "color": "#AB89CD",
+                "order": 0,
+                "__typename": "TransactionTag"
+            },
+            {
+                "id": "200000000000000002",
+                "name": "Alex",
+                "color": "#EF12AB",
+                "order": 1,
+                "__typename": "TransactionTag"
+            }
+        ],
+        "__typename": "Transaction"
+    }
+}

--- a/tests/fixtures/data/split_same_payee_parent.json
+++ b/tests/fixtures/data/split_same_payee_parent.json
@@ -1,0 +1,27 @@
+{
+    "getTransaction": {
+        "id": "100000000000000050",
+        "amount": -0.68,
+        "pending": false,
+        "isRecurring": false,
+        "date": "2026-01-23",
+        "originalDate": "2026-01-23",
+        "hideFromReports": false,
+        "needsReview": false,
+        "reviewedAt": null,
+        "reviewedByUser": null,
+        "plaidName": "DUPLICATE PAYEE MERCHANT",
+        "notes": null,
+        "hasSplitTransactions": true,
+        "isSplitTransaction": false,
+        "isManual": false,
+        "splitTransactions": [
+            {"id": "100000000000000051", "__typename": "Transaction"},
+            {"id": "100000000000000052", "__typename": "Transaction"}
+        ],
+        "originalTransaction": null,
+        "attachments": [],
+        "tags": [],
+        "__typename": "Transaction"
+    }
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,15 +1,19 @@
 """
 Integration tests for main.py — makes real API calls to Monarch Money.
 
-Requirements:
-  - Valid credentials in config.yaml (or environment variables)
-  - The following additional fields in config.yaml:
-      test_mon_account_id      : Monarch account ID for creating test transactions
-      test_mon_category_id     : Monarch category ID used to tag test transactions
-      test_sw_group_member_info: list of {Name, id, is_root} for the test SW group
-      test_root_user           : list with single {id, Name} entry for the root user
-      test_group_id            : dict {"test": {"id": <tag_id>}}
-      test_action_tag          : tag ID for "Not In Splitwise"
+Design principle: test values are owned by this file, not by config.yaml.
+Config.yaml supplies only Monarch wiring (IDs and credentials); all amounts,
+member counts, expected values, and root identity are fixed constants here
+so that assertions don't drift when the user's config changes.
+
+Requirements in config.yaml:
+  - test_mon_account_id       : Monarch account ID for creating test transactions
+  - test_mon_category_id      : Monarch category ID used to tag test transactions
+  - test_sw_group_member_info : list of {Name, id, is_root} — the test picks a
+                                fixed subset (NON_ROOT_COUNT non-root entries)
+  - test_root_user            : list with single {id, Name} entry for the root user
+  - test_group_id             : dict {"test": {"id": <tag_id>}}
+  - test_action_tag           : tag ID for "Not In Splitwise"
 
 These tests create and delete real Monarch transactions.  Do not run in
 production; use a dedicated test account.
@@ -26,6 +30,24 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from main import Main
+
+
+# -----------------------------------------------------------------------------
+# Test-owned fixtures.  Amounts are intentionally non-round so that even splits
+# leave remainder cents and any rounding/fairness bug surfaces.  Member count
+# is fixed so expected values are deterministic regardless of config.yaml size.
+# -----------------------------------------------------------------------------
+NON_ROOT_COUNT = 3
+
+NON_SPLIT_AMOUNT = 1337.13
+SPLIT_PARENT_AMOUNT = -391.68
+SPLIT_CHILD_REIMBURSEE_AMOUNT = -78.34      # root-only payee
+SPLIT_CHILD_REPAYER_AMOUNT = -313.34        # non-root payees; 313.34/3 = 104.44666...
+REFUND_AMOUNT = 17.89                       # positive → refund flow; 17.89/3 = 5.9633...
+SAME_PAYEE_PARENT_AMOUNT = -77.53
+SAME_PAYEE_CHILD_1_AMOUNT = -43.21
+SAME_PAYEE_CHILD_2_AMOUNT = -34.32          # sum = -77.53
+GROUP_ONLY_AMOUNT = -41.73                  # 41.73/4 = 10.4325, forces remainder
 
 
 class TestIntegration(unittest.IsolatedAsyncioTestCase):
@@ -69,8 +91,28 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
             await cls.running.mm.delete_transaction(transaction["id"])
 
     async def asyncSetUp(self):
+        # Fixed test group: 1 root + NON_ROOT_COUNT non-root members taken from config.
+        # Expected values in tests depend on NON_ROOT_COUNT, not on config length.
+        root_entry = self.running_config["test_root_user"][0]
+        self.test_root = {"Name": root_entry["Name"], "id": root_entry["id"]}
+        non_root_all = [
+            {"Name": m["Name"], "id": m["id"]}
+            for m in self.running_config["test_sw_group_member_info"]
+            if not m.get("is_root", False)
+        ]
+        assert len(non_root_all) >= NON_ROOT_COUNT, (
+            f"test_sw_group_member_info must contain at least {NON_ROOT_COUNT} "
+            f"non-root entries; found {len(non_root_all)}"
+        )
+        self.test_non_root = non_root_all[:NON_ROOT_COUNT]
+        # Decouple production root identity from test root so assertions are stable.
+        self.running.config["monarch_user_firstname"] = self.test_root["Name"]
+
         await self.create_non_split_transaction()
         await self.create_split_transaction()
+        await self.create_refund_non_split_transaction()
+        await self.create_split_same_payee_transaction()
+        await self.create_group_only_transaction()
         self.addAsyncCleanup(self.cleanup_created_transactions)
 
     async def cleanup_created_transactions(self):
@@ -80,6 +122,23 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
                 self.transactions_left.append(transaction_id)
 
     # ------------------------------------------------------------------
+    # Helpers (test-owned)
+    # ------------------------------------------------------------------
+
+    def _group_member_info(self):
+        """The Splitwise group_member_info argument for the fixed test subset."""
+        members = [{"first_name": self.test_root["Name"], "memberId": self.test_root["id"]}]
+        for m in self.test_non_root:
+            members.append({"first_name": m["Name"], "memberId": m["id"]})
+        return members
+
+    def _non_root_ids(self):
+        return [m["id"] for m in self.test_non_root]
+
+    def _all_member_ids(self):
+        return [self.test_root["id"]] + self._non_root_ids()
+
+    # ------------------------------------------------------------------
     # Transaction factory helpers
     # ------------------------------------------------------------------
 
@@ -87,7 +146,7 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
         test_transac = await self.running.mm.create_transaction(
             date="2019-08-08",
             account_id=self.running_config["test_mon_account_id"],
-            amount=1337.13,
+            amount=NON_SPLIT_AMOUNT,
             merchant_name="TEST_TRANSACTION",
             category_id=self.running_config["test_mon_category_id"],
             notes="TEST TRANSACTION - Not Split",
@@ -95,13 +154,13 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
         await self.set_test_tag_scheme(
             test_transac["createTransaction"]["transaction"]["id"],
             "not-split",
-            [item["id"] for item in self.running_config["test_sw_group_member_info"]],
+            self._all_member_ids(),
         )
         self.created_transactions["not-split"] = test_transac["createTransaction"]["transaction"]["id"]
 
     async def create_split_transaction(self):
-        parent_total = -391.68
-        split_amounts = [-78.34, -313.34]
+        parent_total = SPLIT_PARENT_AMOUNT
+        split_amounts = [SPLIT_CHILD_REIMBURSEE_AMOUNT, SPLIT_CHILD_REPAYER_AMOUNT]
         tolerance = 1e-2
         assert abs(sum(split_amounts) - parent_total) < tolerance
 
@@ -136,21 +195,98 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
         await self.set_test_tag_scheme(
             child_reimbursee_id,
             "split-child-reimbursee",
-            [item["id"] for item in self.running_config["test_sw_group_member_info"]],
+            self._all_member_ids(),
         )
         await self.set_test_tag_scheme(
             child_repayer_id,
             "split-child-repayer",
-            [item["id"] for item in self.running_config["test_sw_group_member_info"] if not item["is_root"]],
+            self._non_root_ids(),
         )
         self.created_transactions["split-child-reimbursee"] = child_reimbursee_id
         self.created_transactions["split-child-repayer"] = child_repayer_id
+
+    async def create_refund_non_split_transaction(self):
+        '''Positive-amount transaction = refund/income in Monarch.  Same tag scheme
+        as a regular non-split expense; the refund transform is applied downstream.'''
+        test_transac = await self.running.mm.create_transaction(
+            date="2019-08-10",
+            account_id=self.running_config["test_mon_account_id"],
+            amount=REFUND_AMOUNT,
+            merchant_name="TEST_TRANSACTION_REFUND",
+            category_id=self.running_config["test_mon_category_id"],
+            notes="TEST TRANSACTION - Refund, Not Split",
+        )
+        await self.set_test_tag_scheme(
+            test_transac["createTransaction"]["transaction"]["id"],
+            "not-split",
+            self._all_member_ids(),
+        )
+        self.created_transactions["refund-non-split"] = test_transac["createTransaction"]["transaction"]["id"]
+
+    async def create_split_same_payee_transaction(self):
+        '''Split transaction where both children tag the same payee (root user only).
+        Regression fixture for Splitwise's "person included multiple times" error.'''
+        parent_total = SAME_PAYEE_PARENT_AMOUNT
+        split_amounts = [SAME_PAYEE_CHILD_1_AMOUNT, SAME_PAYEE_CHILD_2_AMOUNT]
+        tolerance = 1e-2
+        assert abs(sum(split_amounts) - parent_total) < tolerance
+
+        date = "2019-08-11"
+        account_id = self.running_config["test_mon_account_id"]
+        merchant_name = "TEST_TRANSACTION_SAME_PAYEE"
+        category_id = self.running_config["test_mon_category_id"]
+
+        parent_transaction = await self.running.mm.create_transaction(
+            date=date,
+            account_id=account_id,
+            amount=parent_total,
+            merchant_name=merchant_name,
+            category_id=category_id,
+            notes="Split same-payee - Parent",
+        )
+        parent_transaction_id = parent_transaction["createTransaction"]["transaction"]["id"]
+        self.created_transactions["same-payee-split-parent"] = parent_transaction_id
+
+        split_data = [
+            {"merchantName": merchant_name, "amount": split_amounts[0], "categoryId": str(category_id)},
+            {"merchantName": merchant_name, "amount": split_amounts[1], "categoryId": str(category_id)},
+        ]
+        parent_transaction = await self.running.mm.update_transaction_splits(
+            transaction_id=parent_transaction_id,
+            split_data=split_data,
+        )
+
+        child_1_id = parent_transaction["updateTransactionSplit"]["transaction"]["splitTransactions"][0]["id"]
+        child_2_id = parent_transaction["updateTransactionSplit"]["transaction"]["splitTransactions"][1]["id"]
+
+        # Both children get root as their sole payee → merge_user_shares must consolidate.
+        await self.set_test_tag_scheme(child_1_id, "split-child-reimbursee", [])
+        await self.set_test_tag_scheme(child_2_id, "split-child-reimbursee", [])
+        self.created_transactions["same-payee-split-child-1"] = child_1_id
+        self.created_transactions["same-payee-split-child-2"] = child_2_id
+
+    async def create_group_only_transaction(self):
+        '''Group tagged but no payee tags — exercises the even-split fallback in compute_shares.'''
+        test_transac = await self.running.mm.create_transaction(
+            date="2019-08-12",
+            account_id=self.running_config["test_mon_account_id"],
+            amount=GROUP_ONLY_AMOUNT,
+            merchant_name="TEST_TRANSACTION_GROUP_ONLY",
+            category_id=self.running_config["test_mon_category_id"],
+            notes="TEST TRANSACTION - Group only, no payees",
+        )
+        await self.set_test_tag_scheme(
+            test_transac["createTransaction"]["transaction"]["id"],
+            "group-only",
+            [],
+        )
+        self.created_transactions["group-only"] = test_transac["createTransaction"]["transaction"]["id"]
 
     async def set_test_tag_scheme(self, transaction_id, scheme, group_member_ids):
         if scheme == "not-split":
             tag_dict = {
                 "group_tag_id": self.running_config["test_group_id"]["test"]["id"],
-                "payee": self.running_config["test_root_user"][0]["id"],
+                "payee": self.test_root["id"],
                 "group_members": group_member_ids,
                 "action_tag": self.running_config["test_action_tag"],
             }
@@ -159,13 +295,20 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
         elif scheme == "split-child-reimbursee":
             tag_dict = {
                 "group_tag_id": self.running_config["test_group_id"]["test"]["id"],
-                "payee": self.running_config["test_root_user"][0]["id"],
+                "payee": self.test_root["id"],
                 "action_tag": self.running_config["test_action_tag"],
             }
         elif scheme == "split-child-repayer":
             tag_dict = {
                 "group_tag_id": self.running_config["test_group_id"]["test"]["id"],
                 "group_members": group_member_ids,
+                "action_tag": self.running_config["test_action_tag"],
+            }
+        elif scheme == "group-only":
+            # Group colored tag + action tag, with no payee-colored tags.
+            # Exercises the compute_shares fallback to group_member_info.
+            tag_dict = {
+                "group_tag_id": self.running_config["test_group_id"]["test"]["id"],
                 "action_tag": self.running_config["test_action_tag"],
             }
         else:
@@ -194,20 +337,12 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
     # ------------------------------------------------------------------
 
     async def test_build_user_share_entries_names_present(self):
-        """build_user_share_entries returns all expected member names."""
+        """build_user_share_entries returns non-root payees plus the root payer."""
         transaction_id = self.created_transactions["split-child-repayer"]
         transaction = await self.running.mm.get_transaction_details(transaction_id)
-        group_member_info = [
-            {"first_name": m["Name"], "memberId": m["id"]}
-            for m in self.running_config["test_sw_group_member_info"]
-        ]
-        result = await self.running.build_user_share_entries(transaction, group_member_info)
+        result = await self.running.build_user_share_entries(transaction, self._group_member_info())
 
-        expected_names = [
-            m["Name"]
-            for m in self.running_config["test_sw_group_member_info"]
-            if not m["is_root"]
-        ]
+        expected_names = [m["Name"] for m in self.test_non_root] + [self.test_root["Name"]]
         actual_names = [user["name"] for user in result]
         self.assertCountEqual(actual_names, expected_names)
 
@@ -215,42 +350,128 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
         """Returned userId values correspond to the correct Splitwise member."""
         transaction_id = self.created_transactions["split-child-repayer"]
         transaction = await self.running.mm.get_transaction_details(transaction_id)
-        group_member_info = [
-            {"first_name": m["Name"], "memberId": m["id"]}
-            for m in self.running_config["test_sw_group_member_info"]
-        ]
-        result = await self.running.build_user_share_entries(transaction, group_member_info)
+        result = await self.running.build_user_share_entries(transaction, self._group_member_info())
 
+        name_to_id = {m["Name"]: m["id"] for m in self.test_non_root}
+        name_to_id[self.test_root["Name"]] = self.test_root["id"]
         for user in result:
-            expected_id = next(
-                (m["id"] for m in self.running_config["test_sw_group_member_info"] if m["Name"] == user["name"]),
-                None,
-            )
-            self.assertEqual(user["userId"], expected_id)
+            self.assertEqual(user["userId"], name_to_id[user["name"]])
 
-    async def test_build_user_share_entries_paid_share_values(self):
-        """owed-share values for split-child-repayer are 78.33 or 78.34."""
+    async def test_build_user_share_entries_owed_share_values(self):
+        """Non-root owed-shares are values calculate_shares would produce for the child amount."""
         transaction_id = self.created_transactions["split-child-repayer"]
         transaction = await self.running.mm.get_transaction_details(transaction_id)
-        group_member_info = [
-            {"first_name": m["Name"], "memberId": m["id"]}
-            for m in self.running_config["test_sw_group_member_info"]
-        ]
-        result = await self.running.build_user_share_entries(transaction, group_member_info)
-        for user in result:
-            self.assertIn(user["owed-share"], [78.33, 78.34])
+        result = await self.running.build_user_share_entries(transaction, self._group_member_info())
 
-    async def test_build_user_share_entries_total_paid_share(self):
-        """Total owed-shares across both split children sum to 391.68."""
+        expected_shares = set(self.running.calculate_shares(abs(SPLIT_CHILD_REPAYER_AMOUNT), NON_ROOT_COUNT))
+        for user in result:
+            if user["name"] == self.test_root["Name"]:
+                continue  # root is the payer with owed-share=0 on a repayer child
+            self.assertIn(user["owed-share"], expected_shares)
+
+    async def test_build_user_share_entries_total_owed(self):
+        """Total owed-shares across both split children sum to parent amount."""
         transaction_id = self.created_transactions["split-parent"]
         transaction = await self.running.mm.get_transaction_details(transaction_id)
-        group_member_info = [
-            {"first_name": m["Name"], "memberId": m["id"]}
-            for m in self.running_config["test_sw_group_member_info"]
-        ]
-        result = await self.running.build_user_share_entries(transaction, group_member_info)
+        result = await self.running.build_user_share_entries(transaction, self._group_member_info())
         total = sum(user["owed-share"] for user in result)
-        self.assertAlmostEqual(total, 391.68, places=2)
+        self.assertAlmostEqual(total, abs(SPLIT_PARENT_AMOUNT), places=2)
+
+    # ------------------------------------------------------------------
+    # Refund flow (positive Monarch amount → reverse-roles Splitwise expense)
+    # ------------------------------------------------------------------
+
+    async def test_refund_non_split_satisfies_splitwise_invariants(self):
+        """After to_refund_shares: sum(paid) == sum(owed) == cost."""
+        transaction_id = self.created_transactions["refund-non-split"]
+        transaction = await self.running.mm.get_transaction_details(transaction_id)
+
+        shares = await self.running.build_user_share_entries(transaction, self._group_member_info())
+        refund_shares, refund_cost = self.running.to_refund_shares(shares)
+
+        self.assertAlmostEqual(sum(e["paid-share"] for e in refund_shares), refund_cost, places=2)
+        self.assertAlmostEqual(sum(e["owed-share"] for e in refund_shares), refund_cost, places=2)
+
+    async def test_refund_non_split_reverses_roles(self):
+        """Root becomes sole ower; every other user becomes a payer with owed=0."""
+        transaction_id = self.created_transactions["refund-non-split"]
+        transaction = await self.running.mm.get_transaction_details(transaction_id)
+
+        shares = await self.running.build_user_share_entries(transaction, self._group_member_info())
+        refund_shares, _ = self.running.to_refund_shares(shares)
+
+        for entry in refund_shares:
+            if entry["name"] == self.test_root["Name"]:
+                self.assertEqual(entry["paid-share"], 0)
+                self.assertGreaterEqual(entry["owed-share"], 0)
+            else:
+                self.assertEqual(entry["owed-share"], 0)
+                self.assertGreaterEqual(entry["paid-share"], 0)
+
+    async def test_refund_non_split_cost_is_non_root_portion(self):
+        """Refund cost equals the sum of non-root original owed-shares."""
+        transaction_id = self.created_transactions["refund-non-split"]
+        transaction = await self.running.mm.get_transaction_details(transaction_id)
+
+        shares = await self.running.build_user_share_entries(transaction, self._group_member_info())
+        expected_cost = sum(e["owed-share"] for e in shares if e["name"] != self.test_root["Name"])
+
+        _, refund_cost = self.running.to_refund_shares(shares)
+        self.assertAlmostEqual(refund_cost, expected_cost, places=2)
+
+    # ------------------------------------------------------------------
+    # Split with same payee in every child (Bug 1 regression)
+    # ------------------------------------------------------------------
+
+    async def test_split_same_payee_no_duplicate_user_ids(self):
+        """Each userId appears exactly once — the invariant Splitwise enforces."""
+        transaction_id = self.created_transactions["same-payee-split-parent"]
+        transaction = await self.running.mm.get_transaction_details(transaction_id)
+
+        shares = await self.running.build_user_share_entries(transaction, self._group_member_info())
+        user_ids = [e["userId"] for e in shares]
+        self.assertEqual(len(user_ids), len(set(user_ids)))
+
+    async def test_split_same_payee_total_paid_equals_parent_cost(self):
+        """sum(paid-share) == parent amount when root is the only payee in every split child."""
+        transaction_id = self.created_transactions["same-payee-split-parent"]
+        transaction = await self.running.mm.get_transaction_details(transaction_id)
+
+        shares = await self.running.build_user_share_entries(transaction, self._group_member_info())
+        total_paid = sum(e["paid-share"] for e in shares)
+        self.assertAlmostEqual(total_paid, abs(SAME_PAYEE_PARENT_AMOUNT), places=2)
+
+    async def test_split_same_payee_total_owed_equals_parent_cost(self):
+        """Root's merged owed-share sums to the parent amount across both children."""
+        transaction_id = self.created_transactions["same-payee-split-parent"]
+        transaction = await self.running.mm.get_transaction_details(transaction_id)
+
+        shares = await self.running.build_user_share_entries(transaction, self._group_member_info())
+        total_owed = sum(e["owed-share"] for e in shares)
+        self.assertAlmostEqual(total_owed, abs(SAME_PAYEE_PARENT_AMOUNT), places=2)
+
+    # ------------------------------------------------------------------
+    # Group-only tagging (no payee tags → even-split fallback)
+    # ------------------------------------------------------------------
+
+    async def test_group_only_falls_back_to_group_members(self):
+        """Group tag with no payee tags → every group member gets an owed-share."""
+        transaction_id = self.created_transactions["group-only"]
+        transaction = await self.running.mm.get_transaction_details(transaction_id)
+
+        shares = await self.running.build_user_share_entries(transaction, self._group_member_info())
+        actual_names = {e["name"] for e in shares}
+        expected_names = {self.test_root["Name"]} | {m["Name"] for m in self.test_non_root}
+        self.assertEqual(actual_names, expected_names)
+
+    async def test_group_only_owed_shares_sum_to_amount(self):
+        """Fallback must still preserve the transaction cost invariant."""
+        transaction_id = self.created_transactions["group-only"]
+        transaction = await self.running.mm.get_transaction_details(transaction_id)
+
+        shares = await self.running.build_user_share_entries(transaction, self._group_member_info())
+        total_owed = sum(e["owed-share"] for e in shares)
+        self.assertAlmostEqual(total_owed, abs(GROUP_ONLY_AMOUNT), places=2)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -185,19 +185,12 @@ class TestComputeShares(unittest.IsolatedAsyncioTestCase):
         result = await self.running.compute_shares(self.non_split, MOCK_GROUP_MEMBER_INFO)
         self.assertEqual(len(result), 3)  # Alex, Jake, Jasmine
 
-    async def test_root_user_paid_share_is_full_amount_non_split(self):
-        """Root user (Alex) on a non-split transaction should have paid_share = full amount."""
-        result = await self.running.compute_shares(self.non_split, MOCK_GROUP_MEMBER_INFO)
-        alex_entries = [e for e in result if e["name"] == "Alex"]
-        self.assertEqual(len(alex_entries), 1)
-        self.assertAlmostEqual(alex_entries[0]["paid-share"], 120.00, places=2)
-
-    async def test_non_root_user_paid_share_is_zero(self):
-        """Non-root payees should have paid_share = 0."""
+    async def test_paid_share_always_zero(self):
+        """compute_shares no longer assigns paid-share — build_user_share_entries does,
+        centrally, so root's paid-share is not double-counted across split children."""
         result = await self.running.compute_shares(self.non_split, MOCK_GROUP_MEMBER_INFO)
         for entry in result:
-            if entry["name"] != "Alex":
-                self.assertEqual(entry["paid-share"], 0.00)
+            self.assertEqual(entry["paid-share"], 0.00)
 
     async def test_unknown_payee_name_sets_user_id_none(self):
         """A payee tag whose name does not appear in group_member_info produces userId=None."""
@@ -222,28 +215,48 @@ class TestComputeShares(unittest.IsolatedAsyncioTestCase):
         for entry in result:
             self.assertEqual(entry["userId"], id_map[entry["name"]])
 
-    async def test_split_child_paid_share_uses_original_amount(self):
-        """For a split child where root is payee, paid_share = originalTransaction amount."""
+    async def test_split_child_owed_share_equals_child_amount(self):
+        """For a split child with a single payee, owed-share equals the child amount."""
         result = await self.running.compute_shares(self.child1, MOCK_GROUP_MEMBER_INFO)
-        alex_entries = [e for e in result if e["name"] == "Alex"]
-        self.assertEqual(len(alex_entries), 1)
-        # isSplitTransaction=True → paid_share from originalTransaction.amount * -1
-        self.assertAlmostEqual(alex_entries[0]["paid-share"], 100.00, places=2)
+        total = sum(e["owed-share"] for e in result)
+        self.assertAlmostEqual(total, 60.00, places=2)
 
-    async def test_name_override_with_owed_override_zero_returns_root_entry(self):
-        """When called with a name override and owed_share_array_override=[0],
-        compute_shares should return a single entry for that user with owed-share=0
-        and paid-share equal to the full transaction amount (since they are the root user)."""
-        result = await self.running.compute_shares(
-            self.non_split,
-            MOCK_GROUP_MEMBER_INFO,
-            name_list_override=["Alex"],
-            owed_share_array_override=[0],
-        )
+    async def test_fallback_to_group_members_when_no_payee_tags(self):
+        """When a transaction has a group tag but no payee tags, compute_shares
+        splits evenly across every group member (instead of crashing with div-by-zero)."""
+        transaction = {
+            "getTransaction": {
+                "amount": -40.00,
+                "isSplitTransaction": False,
+                "originalTransaction": None,
+                "tags": [
+                    {"name": "Roomies", "color": "#AB89CD"},
+                ],
+            }
+        }
+        result = await self.running.compute_shares(transaction, MOCK_GROUP_MEMBER_INFO)
+        self.assertEqual(len(result), len(MOCK_GROUP_MEMBER_INFO))
+        total = sum(e["owed-share"] for e in result)
+        self.assertAlmostEqual(total, 40.00, places=2)
+        names = {e["name"] for e in result}
+        self.assertEqual(names, {m["first_name"] for m in MOCK_GROUP_MEMBER_INFO})
+
+    async def test_refund_amount_uses_abs_value(self):
+        """A positive-amount (refund) transaction produces positive owed-shares,
+        which is required before the refund transform can run."""
+        transaction = {
+            "getTransaction": {
+                "amount": 20.00,  # positive = refund in Monarch
+                "isSplitTransaction": False,
+                "originalTransaction": None,
+                "tags": [
+                    {"name": "Alex", "color": "#EF12AB"},
+                ],
+            }
+        }
+        result = await self.running.compute_shares(transaction, MOCK_GROUP_MEMBER_INFO)
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["name"], "Alex")
-        self.assertEqual(result[0]["owed-share"], 0)
-        self.assertAlmostEqual(result[0]["paid-share"], 120.00, places=2)
+        self.assertAlmostEqual(result[0]["owed-share"], 20.00, places=2)
 
 
 # ---------------------------------------------------------------------------
@@ -505,6 +518,205 @@ class TestBuildUserShareEntries(unittest.IsolatedAsyncioTestCase):
         alex = next(e for e in result if e["name"] == "Alex")
         self.assertEqual(alex["owed-share"], 0)
         self.assertAlmostEqual(alex["paid-share"], 90.00, places=2)
+
+
+# ---------------------------------------------------------------------------
+# merge_user_shares
+# ---------------------------------------------------------------------------
+class TestMergeUserShares(unittest.TestCase):
+
+    def setUp(self):
+        self.running = _make_main()
+
+    def test_empty_list_returns_empty(self):
+        self.assertEqual(self.running.merge_user_shares([]), [])
+
+    def test_all_unique_ids_unchanged(self):
+        entries = [
+            {"name": "Alex", "userId": 1001, "paid-share": 10.0, "owed-share": 5.0},
+            {"name": "Jake", "userId": 1002, "paid-share": 0.0,  "owed-share": 5.0},
+        ]
+        result = self.running.merge_user_shares(entries)
+        self.assertEqual(len(result), 2)
+        self.assertAlmostEqual(sum(e["owed-share"] for e in result), 10.0, places=2)
+
+    def test_duplicate_ids_merged_into_one(self):
+        entries = [
+            {"name": "Alex", "userId": 1001, "paid-share": 0.0, "owed-share": 0.44},
+            {"name": "Alex", "userId": 1001, "paid-share": 0.0, "owed-share": 0.24},
+        ]
+        result = self.running.merge_user_shares(entries)
+        self.assertEqual(len(result), 1)
+
+    def test_duplicate_owed_shares_summed(self):
+        entries = [
+            {"name": "Alex", "userId": 1001, "paid-share": 0.0, "owed-share": 0.44},
+            {"name": "Alex", "userId": 1001, "paid-share": 0.0, "owed-share": 0.24},
+        ]
+        result = self.running.merge_user_shares(entries)
+        self.assertAlmostEqual(result[0]["owed-share"], 0.68, places=2)
+
+    def test_duplicate_paid_shares_summed(self):
+        entries = [
+            {"name": "Alex", "userId": 1001, "paid-share": 5.0, "owed-share": 3.0},
+            {"name": "Alex", "userId": 1001, "paid-share": 3.0, "owed-share": 2.0},
+        ]
+        result = self.running.merge_user_shares(entries)
+        self.assertAlmostEqual(result[0]["paid-share"], 8.0, places=2)
+        self.assertAlmostEqual(result[0]["owed-share"], 5.0, places=2)
+
+    def test_partial_duplicates_only_duplicates_merged(self):
+        entries = [
+            {"name": "Alex", "userId": 1001, "paid-share": 0.0, "owed-share": 0.44},
+            {"name": "Alex", "userId": 1001, "paid-share": 0.0, "owed-share": 0.24},
+            {"name": "Jake", "userId": 1002, "paid-share": 0.68, "owed-share": 0.0},
+        ]
+        result = self.running.merge_user_shares(entries)
+        self.assertEqual(len(result), 2)
+        alex = next(e for e in result if e["userId"] == 1001)
+        jake = next(e for e in result if e["userId"] == 1002)
+        self.assertAlmostEqual(alex["owed-share"], 0.68, places=2)
+        self.assertAlmostEqual(jake["paid-share"], 0.68, places=2)
+
+
+# ---------------------------------------------------------------------------
+# Regression: split transaction with same payee in both children (Bug 1)
+# ---------------------------------------------------------------------------
+class TestDuplicatePayeeRegression(unittest.IsolatedAsyncioTestCase):
+    """
+    Regression guard for the 'A person was included on this expense multiple
+    times' Splitwise error.  Triggered when a split transaction has the same
+    payee tagged in every child — each compute_shares call returned a separate
+    entry for that payee, causing Splitwise to reject the expense.
+    """
+
+    def setUp(self):
+        self.running = _make_main()
+        self.parent = load("split_same_payee_parent")
+        self.child1 = load("split_same_payee_child_1")
+        self.child2 = load("split_same_payee_child_2")
+        child_map = {
+            self.child1["getTransaction"]["id"]: self.child1,
+            self.child2["getTransaction"]["id"]: self.child2,
+        }
+        self.running.mm.get_transaction_details = AsyncMock(
+            side_effect=lambda tid: child_map[tid]
+        )
+
+    async def test_same_payee_in_both_children_appears_once(self):
+        """Alex is tagged in both children — must appear only once in the result."""
+        result = await self.running.build_user_share_entries(
+            self.parent, MOCK_GROUP_MEMBER_INFO
+        )
+        alex_entries = [e for e in result if e["name"] == "Alex"]
+        self.assertEqual(len(alex_entries), 1, "Alex should appear exactly once")
+
+    async def test_same_payee_owed_share_is_sum_of_children(self):
+        """Alex's owed-share must be the sum of both child amounts (0.44 + 0.24 = 0.68)."""
+        result = await self.running.build_user_share_entries(
+            self.parent, MOCK_GROUP_MEMBER_INFO
+        )
+        alex = next(e for e in result if e["name"] == "Alex")
+        self.assertAlmostEqual(alex["owed-share"], 0.68, places=2)
+
+    async def test_no_duplicate_user_ids_in_result(self):
+        """No userId should appear more than once — the invariant Splitwise enforces."""
+        result = await self.running.build_user_share_entries(
+            self.parent, MOCK_GROUP_MEMBER_INFO
+        )
+        user_ids = [e["userId"] for e in result]
+        self.assertEqual(len(user_ids), len(set(user_ids)), "Duplicate userId found in result")
+
+    async def test_root_paid_share_not_double_counted(self):
+        """When root user is tagged in multiple split children, paid-share must equal
+        parent amount once — not N × parent. Regression for a bug that was hidden by
+        the duplicate-user error but would have produced paid=1.36 for a 0.68 parent."""
+        result = await self.running.build_user_share_entries(
+            self.parent, MOCK_GROUP_MEMBER_INFO
+        )
+        alex = next(e for e in result if e["name"] == "Alex")
+        parent_amount = abs(self.parent["getTransaction"]["amount"])
+        self.assertAlmostEqual(alex["paid-share"], parent_amount, places=2)
+
+    async def test_split_same_payee_total_paid_equals_cost(self):
+        """sum(paid-share) must equal parent cost exactly — Splitwise's invariant."""
+        result = await self.running.build_user_share_entries(
+            self.parent, MOCK_GROUP_MEMBER_INFO
+        )
+        total_paid = sum(e["paid-share"] for e in result)
+        parent_amount = abs(self.parent["getTransaction"]["amount"])
+        self.assertAlmostEqual(total_paid, parent_amount, places=2)
+
+
+# ---------------------------------------------------------------------------
+# to_refund_shares
+# ---------------------------------------------------------------------------
+class TestToRefundShares(unittest.TestCase):
+    """Reverse-roles refund transformation.  See to_refund_shares docstring for model."""
+
+    def setUp(self):
+        self.running = _make_main()
+
+    def test_two_person_uneven_split(self):
+        """$20 refund, 70/30 split (root paid) → cost $6, root owes $6, friend paid $6."""
+        normal_shares = [
+            {"name": "Alex", "userId": 1001, "paid-share": 20.00, "owed-share": 14.00},
+            {"name": "Jake", "userId": 1002, "paid-share": 0.00,  "owed-share": 6.00},
+        ]
+        new_shares, new_cost = self.running.to_refund_shares(normal_shares)
+        self.assertAlmostEqual(new_cost, 6.00, places=2)
+        alex = next(e for e in new_shares if e["name"] == "Alex")
+        jake = next(e for e in new_shares if e["name"] == "Jake")
+        self.assertEqual(alex["paid-share"], 0)
+        self.assertAlmostEqual(alex["owed-share"], 6.00, places=2)
+        self.assertAlmostEqual(jake["paid-share"], 6.00, places=2)
+        self.assertEqual(jake["owed-share"], 0)
+
+    def test_three_person_even_split(self):
+        """$15 refund, 3-way even split → each non-root gets back $5, root owes $10."""
+        normal_shares = [
+            {"name": "Alex",    "userId": 1001, "paid-share": 15.00, "owed-share": 5.00},
+            {"name": "Jake",    "userId": 1002, "paid-share": 0.00,  "owed-share": 5.00},
+            {"name": "Jasmine", "userId": 1003, "paid-share": 0.00,  "owed-share": 5.00},
+        ]
+        new_shares, new_cost = self.running.to_refund_shares(normal_shares)
+        self.assertAlmostEqual(new_cost, 10.00, places=2)
+        alex = next(e for e in new_shares if e["name"] == "Alex")
+        self.assertAlmostEqual(alex["owed-share"], 10.00, places=2)
+        for other in ["Jake", "Jasmine"]:
+            entry = next(e for e in new_shares if e["name"] == other)
+            self.assertAlmostEqual(entry["paid-share"], 5.00, places=2)
+            self.assertEqual(entry["owed-share"], 0)
+
+    def test_sum_paid_equals_sum_owed_equals_cost(self):
+        """Splitwise invariant: sum(paid) == sum(owed) == cost."""
+        normal_shares = [
+            {"name": "Alex", "userId": 1001, "paid-share": 20.00, "owed-share": 14.00},
+            {"name": "Jake", "userId": 1002, "paid-share": 0.00,  "owed-share": 6.00},
+        ]
+        new_shares, new_cost = self.running.to_refund_shares(normal_shares)
+        self.assertAlmostEqual(sum(e["paid-share"] for e in new_shares), new_cost, places=2)
+        self.assertAlmostEqual(sum(e["owed-share"] for e in new_shares), new_cost, places=2)
+
+    def test_root_only_refund_has_zero_cost(self):
+        """If root was the only payee, no group balance changes — cost = 0 → will be skipped."""
+        normal_shares = [
+            {"name": "Alex", "userId": 1001, "paid-share": 30.00, "owed-share": 30.00},
+        ]
+        new_shares, new_cost = self.running.to_refund_shares(normal_shares)
+        self.assertEqual(new_cost, 0)
+
+    def test_balance_shift_matches_expected_math(self):
+        """$20 refund, 70/30 original. Friend's starting debt $30 → should become $24 (drop $6)."""
+        normal_shares = [
+            {"name": "Alex", "userId": 1001, "paid-share": 20.00, "owed-share": 14.00},
+            {"name": "Jake", "userId": 1002, "paid-share": 0.00,  "owed-share": 6.00},
+        ]
+        new_shares, _ = self.running.to_refund_shares(normal_shares)
+        jake = next(e for e in new_shares if e["name"] == "Jake")
+        # Jake net = paid - owed = +6 → debt decreases by $6 ✓
+        jake_net_change = jake["paid-share"] - jake["owed-share"]
+        self.assertAlmostEqual(jake_net_change, 6.00, places=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes two production bugs observed when uploading Monarch transactions to Splitwise:

- **Refunds (positive Monarch amounts)** were rejected with `Cost must be greater than or equal to 0`. They now produce a reverse-roles Splitwise expense: root becomes the sole ower, non-root payees become payers of their share of the refund.
- **Split transactions tagging the same payee in multiple children** were rejected with `A person was included on this expense multiple times`. `merge_user_shares` now consolidates duplicate userIds before submission.

Also:
- `to_refund_shares` uses integer-cent math (same discipline as `calculate_shares`) so refund distributions can't drift on rounding.
- Success log now distinguishes `refund` from `expense`.
- Integration test values are owned by the test file (fixed member count, non-round amounts chosen to force remainder cents), so assertions don't drift when `config.yaml` changes shape.

## Test plan

- [x] Unit tests pass (`python -m unittest tests.unit.test_unit`)
- [x] Integration tests pass against real Monarch API (`python -m unittest tests.integration.test_integration`) — 12/12
- [x] End-to-end run against production Monarch + Splitwise accounts; refund and expense entries created successfully, including the previously-failing same-payee split